### PR TITLE
fix: exclude items from `isHostile` (fixes #2)

### DIFF
--- a/src/utils/mcdata.js
+++ b/src/utils/mcdata.js
@@ -83,7 +83,12 @@ export function isHuntable(mob) {
 
 export function isHostile(mob) {
     if (!mob || !mob.name) return false;
-    return  (mob.type === 'mob' || mob.type === 'hostile') && mob.name !== 'iron_golem' && mob.name !== 'snow_golem';
+    return (
+        (mob.type === "mob" || mob.type === "hostile") &&
+        mob.name !== "iron_golem" &&
+        mob.name !== "snow_golem" &&
+        mob.name !== "item" // workaround for #2, item.type can be "mob" in some versions
+    );
 }
 
 // blocks that don't work with collectBlock, need to be manually collected


### PR DESCRIPTION
<img width="775" height="590" alt="image" src="https://github.com/user-attachments/assets/f22b9d84-76fc-46ab-9883-e1d9659661b4" />

tested on `Purpur 1.16.5`

fixes #2 